### PR TITLE
Add more props options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+2.5.0
+=====
+
+* (feature) Add more options:
+    *  `overlayClass`: (optional) add a css class to the current `auslese-overlay` making possible styling customizations.
+    *  `hideResetButton`: (optional) hide the reset button. 
+    *  `placeholderLock`: (optional) make the placeholder always visible. It is useful when you want to make visible the placeholder or a custom text and not the selected value(s).
+
+
 2.4.1
 =====
 

--- a/js/Auslese.tsx
+++ b/js/Auslese.tsx
@@ -22,12 +22,15 @@ export interface AusleseProps
     onChange?: (selection: Readonly<AusleseTypes.Selection>) => void;
     dropdownHolder?: HTMLElement;
     dropdownClass?: string|null;
+    overlayClass?: string|null;
     class?: string|null;
     disabled?: boolean;
     placeholder?: string;
+    placeholderLock?: boolean;
     emptyResultsMessage?: string;
     emptyMessage?: string;
     resetText?: string;
+    hideResetButton?: boolean;
     selection?: AusleseTypes.Selection;
     includeGroupHeadlineInChoiceLabel?: boolean;
 
@@ -140,6 +143,7 @@ export class Auslese extends Component<AusleseProps, AusleseState>
         const renderGroups = buildRenderGroups(choices, selection, type, searchQuery);
         const placeholder = props.placeholder || "Bitte wählen";
         const isClearable = selectedChoices.some(choice => !choice.disabled);
+        const hideResetButton = props.hideResetButton || false;
         const hasSearchForm = isSearchable(type, props.searchable, flattened);
         // you can reset the form if it is either multi select or if there is a placeholder
         const canClear = "single" !== type || !!props.placeholder;
@@ -183,7 +187,7 @@ export class Auslese extends Component<AusleseProps, AusleseState>
         {
             render((
                     <Dropdown
-                        isClearable={canClear && isClearable}
+                        isClearable={canClear && isClearable && !hideResetButton}
                         resetText={props.resetText || "Auswahl zurücksetzen"}
                         search={state.search}
                         placeholder={placeholder}
@@ -219,6 +223,7 @@ export class Auslese extends Component<AusleseProps, AusleseState>
                 <CurrentText
                     onClick={event => this.toggleOpen(event)}
                     placeholder={placeholder}
+                    placeholderLock={props.placeholderLock}
                     selected={selectedChoices}
                     includeGroupHeadlineInSelectedChoiceLabel={includeGroupHeadlineInChoiceLabel}
                 />
@@ -244,7 +249,7 @@ export class Auslese extends Component<AusleseProps, AusleseState>
         document.body.removeEventListener("click", this.onBodyClickBound, false);
 
         const dropdown = document.createElement("div");
-        dropdown.setAttribute("class", "auslese-overlay");
+        dropdown.setAttribute("class", "auslese-overlay " + (this.props.overlayClass || ''));
         this.dropdownHolder.appendChild(dropdown);
 
         document.body.addEventListener("click", this.onBodyClickBound, false);

--- a/js/components/CurrentText.tsx
+++ b/js/components/CurrentText.tsx
@@ -9,22 +9,27 @@ interface CurrentTextProps
     onClick: EventListener;
     selected: AusleseTypes.Choice[];
     placeholder: string;
+    placeholderLock?: boolean;
     includeGroupHeadlineInSelectedChoiceLabel: boolean;
 }
 
 export function CurrentText (props: CurrentTextProps): JSX.Element
 {
     const selection = props.selected;
-    const text = selection.length
-        ? filterDuplicateChoices(selection).map(choice => generateHierarchicalChoiceTextLabel(choice, props.includeGroupHeadlineInSelectedChoiceLabel)).join(", ")
-        : props.placeholder;
+    let text = '';
+
+    if (props.placeholderLock || !selection.length) {
+        text = props.placeholder;
+    } else {
+        text = filterDuplicateChoices(selection).map(choice => generateHierarchicalChoiceTextLabel(choice, props.includeGroupHeadlineInSelectedChoiceLabel)).join(", ");
+    }
 
     return (
         <div
             class={classes({
                 "auslese-current": true,
                 "auslese-current-text": true,
-                "auslese-placeholder": !selection.length,
+                "auslese-placeholder": props.placeholderLock || !selection.length,
             })}
             onClick={props.onClick}
         >{text}</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "auslese",
-    "version": "2.5.0",
+    "version": "2.4.1",
     "description": "A tiny + fast choice / dropdown preact component.",
     "license": "BSD-3-Clause",
     "author": "Becklyn Studios <hello@becklyn.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "auslese",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "description": "A tiny + fast choice / dropdown preact component.",
     "license": "BSD-3-Clause",
     "author": "Becklyn Studios <hello@becklyn.com>",

--- a/tests/ava/size-limits.js
+++ b/tests/ava/size-limits.js
@@ -6,7 +6,7 @@ import Terser from "terser";
 // mapping of files to limit
 let files = {
     'index.js': 100,
-    'Auslese.js': 3950,
+    'Auslese.js': 4000,
     'automount.js': 1950,
     'lib/helper.js': 1050,
     'lib/icons.js': 1350,


### PR DESCRIPTION
| Q             | A                                                                     |
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | yes                   |
| Improvement?  | no |
| Bug fix?      | no                                                                |
| Deprecations? | no |
| Docs PR       | **missing** |

Added more options:
    *  `overlayClass`: (optional) add a css class to the current `.auslese-overlay` (located at the root of the `<body>`) making possible styling customisations.
    *  `hideResetButton`: (optional) hide the reset button. 
    *  `placeholderLock`: (optional) make the placeholder always visible. It is useful when you want to make visible the placeholder or a custom text and not the selected value(s).

